### PR TITLE
Clean up trailing whitespace in Calendar

### DIFF
--- a/plugin/calendar.vim
+++ b/plugin/calendar.vim
@@ -1089,6 +1089,13 @@ function! Calendar(...)
     silent put! =vdisplay1
   endif
 
+
+  " Remove Trailing Whitespace
+  let _s=@/
+  %s/\s\+$//e
+  " Clean up: restore previous search history
+  let @/=_s
+
   setlocal nomodifiable
   " In case we've gotten here from insert mode (via <C-O>:Calendar<CR>)...
   stopinsert


### PR DESCRIPTION
This way if listchars is set you won't see the trailing whitespace in the calendar.
