### PR TITLE
Remove ExtraWhitespace highlighting in calendar display

### DIFF
--- a/plugin/calendar.vim
+++ b/plugin/calendar.vim
@@ -1164,6 +1164,9 @@ function! Calendar(...)
     silent execute "normal! gg/\*\<cr>"
   endif
 
+  " clear ExtraWhitespace highlighting
+  execute 'highlight clear ExtraWhitespace'
+
   return ''
 endfunction
 


### PR DESCRIPTION
For users who have ExtraWhitespace highlighting (usually shows trailing whitespace in red), the calendar looks a bit messy. This commit clears that highlight setting for the calendar window. Please let me know if there's a better/more elegant way to do this.
