### PR TITLE
Add vim-formatted documentation to doc/

### DIFF
--- a/doc/calendar.txt
+++ b/doc/calendar.txt
@@ -1,0 +1,183 @@
+*calendar.txt* Calendar utility for vim
+
+Author:  Yasuhiro Matsumoto <mattn.jp@gmail.com>
+
+INTRODUCTION                                    *calendar*
+
+This script creates a calendar window in vim.  It does not rely on any
+external program, such as cal, etc.
+
+COMMANDS                                        *calendar-commands*
+
+calendar.vim makes the following commands available:
+
+                                                *calendar-:Calendar*
+:Calendar [[year] month]  Show calendar at this year and this month in a
+                          vertical split.  When [year] is omitted, the
+                          calendar will show the given month in the current
+                          year.  When both [year] and [month] are omitted, the
+                          calendar will show the current month.
+
+                                                *calendar-:CalendarH*
+:CalendarH [[year] month] Show calendar at this year and this month in a
+                          horizontal split.  When [year] is omitted, the
+                          calendar will show the given month in the current
+                          year.  When both [year] and [month] are omitted, the
+                          calendar will show the current month.
+
+MAPPINGS                                        *calendar-mappings*
+
+calendar.vim makes the following normal mode mappings available:
+
+                                                *calendar-cal*
+<LocalLeader>cal          Brings up the calendar in a vertical split.
+                          Equivalent to calling |:Calendar|.
+
+                                                *calendar-caL*
+<LocalLeader>caL          Brings up the calendar in a horizontal split.
+                          Equivalent to calling |:CalendarH|.
+
+SETTINGS                                        *calendar-settings*
+
+calendar.vim can be configured using the following settings:
+
+                                                *g:calendar_focus_today*
+Keeps focus when moving to next or previous calendar: >
+  let g:calendar_focus_today = 1
+<
+
+                                                *g:calendar_mark*
+Place a '*' or '+' mark after the day.  Acceptable values are 'left',
+'left-fit', and 'right': >
+  let g:calendar_mark = 'right'
+<
+
+                                                *g:calendar_navi*
+To control the calendar navigator, set this variable.  Acceptable values are
+'top', 'bottom', or 'both'. >
+  let g:calendar_navi = ''
+<
+
+                                                *g:calendar_navi_label*
+To set the labels for the calendar navigator, for example to change the
+language, use this variable.  Entries should be comma separated. >
+  let g:calendar_navi_label = 'Prev,Today,Next'
+<
+
+                                                *g:calendar_erafmt*
+To change the dating system, set the following variable.  Include the name of
+the dating system and its offset from the Georgian calendar (A.D.).  For
+example, to use the current Japanese era (Heisei), you would set: >
+  let g:calendar_erafmt = 'Heisei,-1988'
+<
+
+                                                *g:calendar_mruler*
+To change the month names for the calendar headings, set this variable.  The
+value is expected to be a comma-separated list of twelve values, starting with
+Janurary: >
+  let g:calendar_mruler = 'Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec'
+<
+
+                                                *g:calendar_wruler*
+To change the week names for the calendar headings, set this variable.  The
+value is expected to be a space-separated list of seven values, starting with
+Sunday: >
+  let g:calendar_wruler = 'Su Mo Tu We Th Fr Sa'
+<
+
+                                                *g:calendar_monday*
+To make the week start on Monday rather than Sunday, set this variable.  Note
+that the value of |g:calendar_wruler| is not affected by this; it should
+always begin with Sunday: >
+  let g:calendar_monday = 1
+<
+
+                                                *g:calendar_weeknm*
+To show the week number, set this variable.  There are four valid settings: >
+  let g:calendar_weeknm = 1 " WK01
+  let g:calendar_weeknm = 2 " WK 1
+  let g:calendar_weeknm = 3 " KW01
+  let g:calendar_weeknm = 4 " KW 1
+<
+
+                                                *g:calendar_datetime*
+To control display of the current date and time, set this variable.
+Acceptable values are 'title', 'statusline', and '': >
+  let g:calendar_datetime = 'title'
+<
+
+HOOKS                                           *calendar-hooks*
+
+calendar.vim provides a number of hooks which allow you to run custom code on
+certain events.  These are documented below.
+
+                                                *calendar_action*
+The function declared in the calendar_action variable is run when the user
+presses enter on a date.  Implement and set your function as follows: >
+  function MyCalAction(day,month,year,week,dir)
+    " day   : day you actioned
+    " month : month you actioned
+    " year  : year you actioned
+    " week  : day of week (Mo=1 ... Su=7)
+    " dir   : direction of calendar
+  endfunction
+  let calendar_action = 'MyCalAction'
+<
+
+                                                *calendar_begin*
+The function declared in the calendar_begin variable is run just before the
+calendar is displayed.  Implement and set your function as follows: >
+  function MyCalActionBegin()
+  endfunction
+  let calendar_begin = 'MyCalActionBegin'
+<
+
+                                                *calendar_end*
+The function declared in the calendar_end variable is run just after the
+calendar is displayed.  Implement and set your function as follows: >
+  function MyCalActionEnd()
+  endfunction
+  let calendar_end = 'MyCalActionEnd'
+<
+
+                                                *calendar_sign*
+The function declared in the calendar_sign variable can be used to set a mark
+next to certain dates.  Implement and set your function as follows: >
+  function MyCalSign(day,month,year)
+    " day   : day you actioned
+    " month : month you actioned
+    " year  : year you actioned
+    if a:day == 1 && a:month == 1
+      return 1 " happy new year
+    else
+      return 0 " or not
+    endif
+  endfunction
+  let calendar_sign = 'MyCalSign'
+<
+
+                                                *calendar_today*
+The function declared in the calendar_today variable is run when the user
+presses 'today'.  Implement and set your function as follows: >
+  function MyCalToday()
+  endfunction
+  let calendar_today = 'MyCalToday'
+<
+
+ABOUT                                           *calendar-about*
+
+calendar.vim is available on GitHub:
+
+  http://github.com/mattn/calendar.vim
+
+and also on VimScripts:
+
+  http://www.vim.org/scripts/script.php?script_id=52
+
+                                                *calendar_version*
+In order to see which version of the script you are running, enter the
+following at the vim command line: >
+  :echo calendar_version
+<
+
+vim:tw=78:et:ft=help:norl:


### PR DESCRIPTION
Finding the documentation currently requires the user to read comments
embedded at the top of the plugin code.  Add vim-formatted documentation
so that a new user can simply run ':help calendar' to get started.
