### PR TITLE
Fixed window problem when using :CalendarH

### DIFF
--- a/plugin/calendar.vim
+++ b/plugin/calendar.vim
@@ -1105,7 +1105,7 @@ function! s:CalendarDiary(day, month, year, week, dir)
   let vbufnr = bufnr('__Calendar')
 
   " load the file
-  exe "wincmd l"
+  exe "wincmd w"
   exe "edit  " . sfile
   let dir = getbufvar(vbufnr, "CalendarDir")
   let vyear = getbufvar(vbufnr, "CalendarYear")


### PR DESCRIPTION
When using :CalendarH, if you press [enter] on a date string, a diary file will be opened in the same window. Thus a calendar view will disappear. This is not the action we want, so I changed the script to open a diary file in a different window. To do this cleverer, you can use "wincmd l" in :Calendar mode and "wincmd k" in :CalendarH mode, but in most cases "wincmd w" (the command I chose) will do the right thing.
