### PR TITLE
Fix existing diary was not found correctly.

### DIFF
--- a/autoload/calendar.vim
+++ b/autoload/calendar.vim
@@ -1063,7 +1063,7 @@ endfunc
 "*   year  : year of sign
 "*****************************************************************
 function! calendar#sign(day, month, year)
-  let sfile = g:calendar_diary."/".a:year."/".a:month."/".a:day.".md"
+  let sfile = g:calendar_diary."/".printf("%04d", a:year)."/".printf("%02d", a:month)."/".printf("%02d", a:day).".md"
   return filereadable(expand(sfile))
 endfunction
 


### PR DESCRIPTION
In ec1d245bfa8d66027dad2d8ba48ecc6e70674fce , format of a filename was
changed. However, the function calendar#sign was not changed, thus the
function was not able to find diary files. This commit fixes the search
path.
