### PR TITLE
Set filetype to markdown when loading a diary file

### DIFF
--- a/autoload/calendar.vim
+++ b/autoload/calendar.vim
@@ -1052,6 +1052,7 @@ function! calendar#diary(day, month, year, week, dir)
   " load the file
   exe "wincmd w"
   exe "edit  " . sfile
+  setfiletype markdown
   let dir = getbufvar(vbufnr, "CalendarDir")
   let vyear = getbufvar(vbufnr, "CalendarYear")
   let vmnth = getbufvar(vbufnr, "CalendarMonth")


### PR DESCRIPTION
In default, Vim considers ".md" files as modula2 files. While many
people seem to use plugins such as "vim-markdown", which override
filetype of modula2, it seems to be more considerate to set the
filetype manually when a diary file is loaded.
