### PR TITLE
Added option to customize calendar's diary file extension

### DIFF
--- a/autoload/calendar.vim
+++ b/autoload/calendar.vim
@@ -1051,7 +1051,7 @@ function! calendar#diary(day, month, year, week, dir)
       return
     endif
   endif
-  let sfile = expand(sfile) . "/" . printf("%02d", a:day) . expand(g:calendar_diary_extension)
+  let sfile = expand(sfile) . "/" . printf("%02d", a:day) . g:calendar_diary_extension
   let sfile = substitute(sfile, ' ', '\\ ', 'g')
   let vbufnr = bufnr('__Calendar')
 

--- a/autoload/calendar.vim
+++ b/autoload/calendar.vim
@@ -41,6 +41,9 @@ endif
 if !exists("g:calendar_filetype")
   let g:calendar_filetype = "markdown"
 endif
+if !exists("g:calendar_diary_extension")
+    let g:calendar_diary_extension = ".md"
+endif
 
 "*****************************************************************
 "* Default Calendar key bindings
@@ -1048,7 +1051,7 @@ function! calendar#diary(day, month, year, week, dir)
       return
     endif
   endif
-  let sfile = expand(sfile) . "/" . printf("%02d", a:day) . ".md"
+  let sfile = expand(sfile) . "/" . printf("%02d", a:day) . expand(g:calendar_diary_extension)
   let sfile = substitute(sfile, ' ', '\\ ', 'g')
   let vbufnr = bufnr('__Calendar')
 


### PR DESCRIPTION
The extension of the file is always .md, while opening the diary file
automatically sets the ft to `g:calendar_filetype` value it sometimes
could be useful to open the file directly without the calendar plugin.
So I added a new key `g:calendar_diary_extension` to allow setting custom
extension to diary file. Defaults to:
`let g:calendar_diary_extension = ".md"`
