### PR TITLE
Add variable g:calendar_diary_flat_structure to enable storing diary files on a single folder

### DIFF
--- a/autoload/calendar.vim
+++ b/autoload/calendar.vim
@@ -44,6 +44,9 @@ endif
 if !exists("g:calendar_diary_extension")
     let g:calendar_diary_extension = ".md"
 endif
+if !exists("g:calendar_diary_flat_structure")
+  let g:calendar_diary_flat_structure = 0
+endif
 
 "*****************************************************************
 "* Default Calendar key bindings
@@ -1042,19 +1045,27 @@ function! calendar#diary(day, month, year, week, dir)
     call confirm("please create diary directory : ".g:calendar_diary, 'OK')
     return
   endif
-  let sfile = expand(g:calendar_diary) . "/" . printf("%04d", a:year)
-  if isdirectory(sfile) == 0
-    if s:make_dir(sfile) != 0
-      return
+  if g:calendar_diary_flat_structure
+      " diary files organized in flat folder structure
+      " dir/yyyy-mm-dd.(g:calendar_diary_extension)
+      let sfile = expand(sfile) . "/" . printf("%04d-%02d-%02d", a:year, a:month, a:day) . g:calendar_diary_extension
+  else
+    " diary files organized in tree folder structure
+    " dir/year/mont/day.(g:calendar_diary_extension)
+    let sfile = expand(g:calendar_diary) . "/" . printf("%04d", a:year)
+    if isdirectory(sfile) == 0
+      if s:make_dir(sfile) != 0
+        return
+      endif
     endif
-  endif
-  let sfile = sfile . "/" . printf("%02d", a:month)
-  if isdirectory(sfile) == 0
-    if s:make_dir(sfile) != 0
-      return
+    let sfile = sfile . "/" . printf("%02d", a:month)
+    if isdirectory(sfile) == 0
+      if s:make_dir(sfile) != 0
+        return
+      endif
     endif
+    let sfile = expand(sfile) . "/" . printf("%02d", a:day) . g:calendar_diary_extension
   endif
-  let sfile = expand(sfile) . "/" . printf("%02d", a:day) . g:calendar_diary_extension
   let sfile = substitute(sfile, ' ', '\\ ', 'g')
   let vbufnr = bufnr('__Calendar')
 

--- a/autoload/calendar.vim
+++ b/autoload/calendar.vim
@@ -1048,7 +1048,7 @@ function! calendar#diary(day, month, year, week, dir)
   if g:calendar_diary_flat_structure
       " diary files organized in flat folder structure
       " dir/yyyy-mm-dd.(g:calendar_diary_extension)
-      let sfile = expand(sfile) . "/" . printf("%04d-%02d-%02d", a:year, a:month, a:day) . g:calendar_diary_extension
+      let sfile = expand(g:calendar_diary) . "/" . printf("%04d-%02d-%02d", a:year, a:month, a:day) . g:calendar_diary_extension
   else
     " diary files organized in tree folder structure
     " dir/year/mont/day.(g:calendar_diary_extension)

--- a/doc/calendar.txt
+++ b/doc/calendar.txt
@@ -92,10 +92,9 @@ Specify the directory for the diary files.  The default value is $HOME/diary.
   let g:calendar_diary=$HOME.'/.vim/diary'
 
                                                 *g:calendar_diary_flat_structure*
-To store all the diary files in a flat file structure in the g:calendar_diary 
-folder with no subfolder and filenames in the 
-form YYYY-MM-DD.(g:calendar_diary_extension), set this variable to a value 
-different than 0.  Default value is 0. >
+To store all the diary files in a flat folder structure in the g:calendar_diary 
+folder with filenames in the form YYYY-MM-DD.(g:calendar_diary_extension), set 
+this variable to a value  different than 0.  Default value is 0. >
   let g:calendar_diary_flat_structure = 1
 <
 

--- a/doc/calendar.txt
+++ b/doc/calendar.txt
@@ -91,6 +91,13 @@ Place a '*' or '+' mark after the day.  Acceptable values are 'left',
 Specify the directory for the diary files.  The default value is $HOME/diary.
   let g:calendar_diary=$HOME.'/.vim/diary'
 
+                                                *g:calendar_diary_flat_structure*
+To store all the diary files in a flat file structure in the g:calendar_diary 
+folder with no subfolder and filenames in the 
+form YYYY-MM-DD.(g:calendar_diary_extension), set this variable to a value 
+different than 0.  Default value is 0. >
+  let g:calendar_diary_flat_structure = 1
+<
 
                                                 *g:calendar_navi*
 To control the calendar navigator, set this variable.  Acceptable values are


### PR DESCRIPTION
This PR adds the variable `g:calendar_diary_flat_structure`, if its value is different than 0, it makes the plugin to store all the diary files in the folder `g:calendar_diary`, no creating subfolders for each year nor month. When enabled, the filenames for the diary entries are in the form `YYYY-MM-DD.(g:calendar_diary_extension`.

By default the variable `g:calendar_diary_flat_structure` takes value 0, so this new option is disabled by default, not changing the current behaviour of the plugin regarding the storage of diary entries.