### PR TITLE
fix: detect relativenumber feature by existis

### DIFF
--- a/autoload/calendar.vim
+++ b/autoload/calendar.vim
@@ -42,7 +42,7 @@ if !exists("g:calendar_datetime")
 endif
 if !exists("g:calendar_options")
   let g:calendar_options = "fdc=0 nonu"
-  if has("+relativenumber")
+  if has("+relativenumber") || exists("+relativenumber")
     let g:calendar_options .= " nornu"
   endif
 endif
@@ -906,7 +906,7 @@ function! calendar#show(...)
     setlocal bufhidden=delete
     silent! exe "setlocal " . g:calendar_options
     let nontext_columns = &foldcolumn + &nu * &numberwidth
-    if has("+relativenumber")
+    if has("+relativenumber") || exists("+relativenumber")
       let nontext_columns += &rnu * &numberwidth
     endif
     " Without this, the 'sidescrolloff' setting may cause the left side of the


### PR DESCRIPTION
"+relativenumber" is not more in the ["feature-list"](https://vimhelp.org/builtin.txt.html#feature-list) 
or ["+feature-list"](https://vimhelp.org/various.txt.html#%2Bfeature-list),
it is ["+option-name"](https://vimhelp.org/builtin.txt.html#exists%28%29) for now.